### PR TITLE
Correção de Spam de arquivos

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -64,13 +64,22 @@ namespace BitcoinAddressSearch
                 BitcoinAddress addressKey = secretKey.PubKey.GetAddress(Network.Main);
 
                 String ret = Get("https://blockchain.info/q/addressbalance/" + addressKey.ToString());
-                if (ret != "0")
+                
+                string Str = ret;
+                double Num;
+
+                bool isNum = double.TryParse(Str, out Num);
+
+                if (isNum == true)
                 {
-                    Console.WriteLine("************ Check this out     Secret :" + secretKey + "         Key :" + addressKey.ToString());
-                    string s = secretKey + " ----- " + addressKey.ToString();
-                    System.IO.File.WriteAllText(location + "BitcoinAddres-" + addressKey.ToString() + ".txt", s);
+                    if (ret != "0")
+                    {
+                        Console.WriteLine("************ Check this out     Secret :" + secretKey + "         Key :" + addressKey.ToString());
+                        string s = secretKey + " ----- " + addressKey.ToString() + " ---- " + ret;
+                        System.IO.File.WriteAllText(location + "BitcoinAddres-" + addressKey.ToString() + ".txt", s);
+                    }
                 }
-            }
+                }
             catch
 
             { 


### PR DESCRIPTION
O Seguinte commit corrige o erro de spam de arquivos .txt com endereços de valores 0 mas por conta de estar sem resposta do servidor, estavá considerando que o tal endereço possuia moedas, Foi adicionado um verificador desse valor para ver se ele é algum numero, excluido o problema de não resposta do servidor e evitando o Spam.